### PR TITLE
fix php8.2 return type warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": ">=5.6"
+        "php": ">=8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5"

--- a/src/Result/Failure.php
+++ b/src/Result/Failure.php
@@ -41,7 +41,7 @@ abstract class Failure extends Base
         return $this->getContext();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Result/Success.php
+++ b/src/Result/Success.php
@@ -29,7 +29,7 @@ class Success extends Base
         return $this->response_data;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }


### PR DESCRIPTION
`Return type of MattyRad\Support\Result\Failure::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/mattyrad/support/src/Result/Failure.php on line 44
`

